### PR TITLE
Load sweep current signals one at a time to reduce memory burden

### DIFF
--- a/lapd_plasma_analysis/langmuir/analysis.py
+++ b/lapd_plasma_analysis/langmuir/analysis.py
@@ -3,8 +3,8 @@ from lapd_plasma_analysis.experimental import get_exp_params
 
 from lapd_plasma_analysis.langmuir.helper import *
 from lapd_plasma_analysis.langmuir.configurations import *
-from lapd_plasma_analysis.langmuir.getIVsweep import get_isweep_vsweep
-from lapd_plasma_analysis.langmuir.characterization import characterize_sweep_array
+from lapd_plasma_analysis.langmuir.getIVsweep import get_sweep_voltage, get_sweep_current, get_shot_positions
+from lapd_plasma_analysis.langmuir.characterization import make_characteristic_array, isolate_ramps
 from lapd_plasma_analysis.langmuir.preview import preview_raw_sweep, preview_characteristics
 from lapd_plasma_analysis.langmuir.diagnostics import (langmuir_diagnostics, detect_steady_state_times, get_pressure,
                                                        get_electron_ion_collision_frequencies)
@@ -167,19 +167,58 @@ def load_datasets(hdf5_folder, lang_nc_folder, bimaxwellian, plot_save_directory
             voltage_gain = get_voltage_gain(config_id)
             orientation = get_orientation(config_id)
 
-            # get current and bias data from Langmuir probe
-            bias, currents, positions, dt = get_isweep_vsweep(hdf5_path, vsweep_board_channel,
-                                                              langmuir_configs, voltage_gain, orientation)
+            # todo revise get current and bias data from Langmuir probe and store in...
+            bias, dt = get_sweep_voltage(hdf5_path, vsweep_board_channel, voltage_gain)
+            ramp_bounds = isolate_ramps(bias)
+            ramp_times = ramp_bounds[:, 1] * dt.to(u.ms)
+            # todo NOTE: MATLAB code stores peak voltage time (end of plateaus), then only uses plateau times for very first position
+            #  This uses the time of the peak voltage for the average of all shots ("top of the average ramp")
 
-            if sweep_view_mode:
-                preview_raw_sweep(bias, currents, positions, langmuir_configs[['port', 'face']], exp_params_dict, dt,
-                                  plot_save_directory=plot_save_directory)
+            # This for loop extracts sweep data and creates Characteristic objects
+            characteristic_arrays = []
+            position_arrays = []
+            for i in range(len(langmuir_configs)):
+                current, motor_data = get_sweep_current(hdf5_path, langmuir_configs[i], orientation)
 
-            # organize sweep bias and current into an array of Characteristic objects
-            characteristics, ramp_times = characterize_sweep_array(bias, currents, dt)
+                # ensure "hardcoded" ports listed in configurations.py match those listed in HDF5 file
+                assert motor_data.info['controls']['6K Compumotor']['probe']['port'] == langmuir_configs[i]['port']
 
-            # cleanup 1
-            del bias, currents
+                position_array, num_positions, shots_per_position, selected_shots = get_shot_positions(motor_data)
+                position_arrays += [position_array]
+
+                # Drop some shots from the data because they don't fit into a 3D structure
+                if len(bias.shape) == 2:  # already selected certain shots in bias data
+                    bias = bias[selected_shots, ...]
+                current = current[selected_shots, ...]
+
+                # Make bias and current 3D (position, shot_at_a_certain_position, frame) arrays
+                #    as opposed to 2D (shot number, frame) arrays
+                bias = bias.reshape(num_positions,       shots_per_position, -1)
+                current = current.reshape(num_positions, shots_per_position, -1)
+                # Dimensions of bias and current arrays:   position, shot, frame   (e.g. (71, 15, 55296))
+
+                if sweep_view_mode:
+                    preview_raw_sweep(bias, current, position_array, langmuir_configs[i], exp_params_dict, dt,
+                                      plot_save_directory=plot_save_directory)
+
+                # organize sweep bias and current into a 3D array of Characteristic objects
+                characteristic_array = make_characteristic_array(bias, current, ramp_bounds)
+                characteristic_arrays += [characteristic_array]
+
+                # cleanup 1
+                del current
+
+            # cleanup 2
+            del bias
+
+            # Check that all probes access the same positions at all times. Independent probe positions not implemented
+            assert np.all([position == position_arrays[0] for position in position_arrays])
+            positions = position_arrays[0]
+
+            characteristics = np.stack(characteristic_arrays, axis=0)
+            # Above: characteristics has one extra dimension "in front",
+            #  to represent characteristics (sweep curves) from different probes or probe faces.
+            #  Probe/face combinations are ordered by the order of elements in langmuir_configs, from configurations.py.
 
             if chara_view_mode:
                 preview_characteristics(characteristics, positions, ramp_times,
@@ -192,7 +231,7 @@ def load_datasets(hdf5_folder, lang_nc_folder, bimaxwellian, plot_save_directory
             diagnostics_dataset = langmuir_diagnostics(characteristics, positions, ramp_times,
                                                        langmuir_configs, ion_type, bimaxwellian=bimaxwellian)
 
-            # cleanup 2
+            # cleanup 3
             del characteristics, positions
 
             diagnostics_dataset = diagnostics_dataset.assign_attrs(exp_params_dict)

--- a/lapd_plasma_analysis/langmuir/analysis.py
+++ b/lapd_plasma_analysis/langmuir/analysis.py
@@ -116,10 +116,10 @@ def print_user_file_choices(hdf5_folder, lang_nc_folder, interferometry_folder, 
     print(f"Interferometry mode is {repr(interferometry_mode)}. "
           f"Calibrated density data will be {interferometry_mode_actions[interferometry_mode]}.")
 
-    print("Current HDF5 directory path:           \t", repr(hdf5_folder),
+    print("Current HDF5 directory path:             \t", repr(hdf5_folder),
           "\nCurrent NetCDF directory path:         \t", repr(lang_nc_folder),
           "\nCurrent interferometry directory path: \t", repr(interferometry_folder),
-          "\nLinear combinations of isweep sources:   \t", repr(isweep_choices),
+          "\nLinear combinations of isweep sources: \t", repr(isweep_choices),
           "\nThese can be changed in main.py.")
     input("Enter any key to continue: ")
 

--- a/lapd_plasma_analysis/langmuir/analysis.py
+++ b/lapd_plasma_analysis/langmuir/analysis.py
@@ -154,7 +154,7 @@ def load_datasets(hdf5_folder, lang_nc_folder, bimaxwellian, plot_save_directory
         datasets = []
         for hdf5_path in hdf5_chosen_list:
 
-            print("\nOpening file", repr(hdf5_path), "...")
+            print(f"\nOpening file {repr(hdf5_path)} ...")
 
             exp_params_dict = get_exp_params(hdf5_path)  # list of experimental parameters
 

--- a/lapd_plasma_analysis/langmuir/characterization.py
+++ b/lapd_plasma_analysis/langmuir/characterization.py
@@ -9,9 +9,12 @@ from lapd_plasma_analysis.langmuir.helper import *
 
 def make_characteristic_array(bias, current, ramp_bounds):
     """
-    Function that processes bias and current data into a DataArray of distinct Characteristics.
-    Takes in bias and current arrays, smooths them, divides them into separate ramp sections, 
-    and creates a Characteristic object for each ramp at each unique x,y position.
+    Process bias and current data into an array of Characteristic objects, each representing one sweep curve.
+    The resulting array is 3D, with dimensions: unique (x, y) position, shot, ramp. # todo explain ramp WIP
+    Takes in bias and current arrays,  divides them into separate ramp sections, and creates a Characteristic object 
+    for each ramp at each unique x,y position.
+    Later concatenated with 3D arrays from other isweeps (other sources of sweep current, e.g.
+     faces on a Langmuir probe) to make a larger 4D array to pass to diagnostics.py.
 
     Parameters
     ----------

--- a/lapd_plasma_analysis/langmuir/getIVsweep.py
+++ b/lapd_plasma_analysis/langmuir/getIVsweep.py
@@ -60,19 +60,13 @@ def get_sweep_current(filename, isweep_metadata, orientation):
     """
 
     with lapd.File(filename) as lapd_file:
-        isweep_bcs = np.atleast_1d(isweep_metadatas[['board', 'channel']])
+        # TODO revise
+        #  isweep_metadata is a structured Numpy array storing the digitizer and motor information for Langmuir probes.
+        #  It can have one or zero dimensions. Zero dimensions is possible if there is only one source of sweep current.
 
-        vsweep = lapd_file.read_data(*vsweep_bc, silent=True)
-        isweep = [lapd_file.read_data(*isweep_bc, silent=True) for isweep_bc in isweep_bcs]
-        dt = vsweep.dt
+        isweep = lapd_file.read_data(isweep_metadata['board'], isweep_metadata['channel'], silent=True)['signal']
 
-        vsweep = vsweep['signal']
-        isweep = np.concatenate([isweep_signal['signal'][np.newaxis, ...] for isweep_signal in isweep], axis=0)
-        # Above: isweep_signal has one extra dimension "in front" compared to vsweep signal,
-        #  to represent different probes or probe faces; ordered by (board, channel) as listed in isweep_metadatas
-        signal_length = vsweep.shape[-1]
-
-        # List of motor data about the probe associated with each isweep signal.
+        # TODO revise List of motor data about the probe associated with each isweep signal.
         #   Motor data may be repeated, for example if two isweep signals were taken using two faces on the same probe.
         motor_data = lapd_file.read_controls([("6K Compumotor", isweep_metadata['receptacle'])], silent=True)
 

--- a/lapd_plasma_analysis/langmuir/getIVsweep.py
+++ b/lapd_plasma_analysis/langmuir/getIVsweep.py
@@ -49,16 +49,14 @@ def get_sweep_current(filename, isweep_metadata, orientation):
     ----------
     filename : `str`
         file path of HDF5 file from LAPD (WIP)
-    vsweep_bc : `tuple` or `list`
-        board and channel number of vsweep data in HDF5 file (WIP)
-    isweep_metadatas : `numpy.ndarray`
+    isweep_metadata : `numpy.ndarray` of `int` and `str`
         structured array of board, channel, receptacle, port, face, resistance, and area for each isweep signal (WIP)
     orientation : {+1, -1}
         +1 or -1, depending on if Isweep should be inverted before analysis (WIP)
 
     Returns
     -------
-    bias, currents, positions, dt: v_sweep array, i_sweeps array, position array, and timestep amount (WIP)
+    bias, current, positions, dt: v_sweep array, i_sweeps array, position array, and timestep amount (WIP)
     """
 
     with lapd.File(filename) as lapd_file:
@@ -76,44 +74,20 @@ def get_sweep_current(filename, isweep_metadata, orientation):
 
         # List of motor data about the probe associated with each isweep signal.
         #   Motor data may be repeated, for example if two isweep signals were taken using two faces on the same probe.
-        motor_datas = [lapd_file.read_controls([("6K Compumotor", isweep_metadata['receptacle'])], silent=True)
-                       for isweep_metadata in isweep_metadatas]
-
-    # TODO allow isweep motor datas to be different or check
-    #
-    #  for now, assume identical and use only first motor data
-    num_isweep = len(isweep_metadatas)
-    positions, num_positions, shots_per_position, selected_shots = get_shot_positions(motor_datas[0])
-    vsweep = vsweep[selected_shots,    ...]
-    isweep = isweep[:, selected_shots, ...]
-
-    vsweep = vsweep.reshape(num_positions,              shots_per_position, signal_length)
-    isweep = isweep.reshape((num_isweep, num_positions, shots_per_position, signal_length))
-
-    # Add length-one dimensions to the end of resistances and gains to match the isweep array
-    scale_slices = [slice(0, num_isweep)] + [None for _ in range(len(isweep.shape) - 1)]
-    resistances = isweep_metadatas['resistance'][*scale_slices]
-    gains = isweep_metadatas['gain'][*scale_slices]
+        motor_data = lapd_file.read_controls([("6K Compumotor", isweep_metadata['receptacle'])], silent=True)
 
     # Convert to real units (not abstract)
-    bias = vsweep * voltage_gain * u.V
-    currents = isweep / resistances / gains * u.A
+    current = isweep / isweep_metadata['resistance'] / isweep_metadata['gain'] * u.A
 
     # Subtract out average of last thousand current measurements for each isweep signal,
     #   as this should be a while after the plasma has dissipated and thus be equal to zero.
     #   This eliminates any persistent DC offset current from the probe.
-    currents -= np.mean(currents[..., -1000:], axis=-1, keepdims=True)
-
-    # bias dimensions:               position, shot, frame   (e.g.    (71, 15, 55296))
-    # currents dimensions:   isweep, position, shot, frame   (e.g. (1, 71, 15, 55296))
+    current -= np.mean(current[..., -1000:], axis=-1, keepdims=True)
 
     # Up-down orientation of sweep is hardcoded for an entire experiment, e.g. November_2022, in configurations.py
-    currents *= orientation
+    current *= orientation
 
-    ports = np.array([motor_data.info['controls']['6K Compumotor']['probe']['port'] for motor_data in motor_datas])
-    assert np.all(ports == isweep_metadatas['port'])  # otherwise, ports in configurations.py do not match motor data
-
-    return bias, currents, positions, dt
+    return current, motor_data
 
 
 def get_shot_positions(isweep_motor_data):

--- a/lapd_plasma_analysis/langmuir/helper.py
+++ b/lapd_plasma_analysis/langmuir/helper.py
@@ -131,12 +131,13 @@ def core_steady_state(da_input, core_rad=None, steady_state_times=None, operatio
        Two-element quantity giving start and end times of steady-state period, inclusive.
     operation : {"mean", "median", "std", "std_error"}, optional
         Operation to perform on core/steady_state data on all dimensions but those specified in `dims_to_keep`.
-             - "mean" calculates the mean diagnostic value in the core/steady-state region.
-             - "median" calculates the median diagnostic value in the core/steady-state region.
-             - "std" calculates the standard deviation of the diagnostic values in the core/steady-state region.
-             - "std_error" calculates the unbiased standard error, or 95% confidence interval radius, of the (hypothetical) mean
-              of each value in the array that would result if a mean were performed over all dimensions
-              not specified in `dims_to_keep`. NaN values are removed from the degrees of freedom of the standard error.
+          - "mean" calculates the mean diagnostic value in the core/steady-state region.
+          - "median" calculates the median diagnostic value in the core/steady-state region.
+          - "std" calculates the standard deviation of the diagnostic values in the core/steady-state region.
+          - "std_error" calculates the unbiased standard error, or 95% confidence interval radius,
+            of the (hypothetical) mean of each value in the array that would result
+            if a mean were performed over all dimensions not specified in `dims_to_keep`.
+            NaN values are removed from the degrees of freedom of the standard error.
     dims_to_keep: `list` or `tuple`, default=(None,)
         List or tuple of dimension names not to calculate statistics across, or None to leave all dimensions intact.
         If not None, the resulting array will have only the dimensions given by `dims_to_keep`.

--- a/lapd_plasma_analysis/langmuir/helper.py
+++ b/lapd_plasma_analysis/langmuir/helper.py
@@ -72,25 +72,45 @@ def get_diagnostic_keys_units(probe_area=1.*u.mm**2, ion_type="He-4+", bimaxwell
 
 def probe_face_selector(ds, vectors):
     """
-    Select an isweep signal, linear combination of isweep signals, or multiple such linear combinations from a
-    diagnostic dataset. For example, on a dataset with two isweep signals (e.g. from 2 different probes or probe faces),
-        - [1,  0] would return the data from the first isweep signal (listed first in configurations.py)
-        - [1, -1] would return the parallel difference (first-listed minus second-listed)
-        - [[1, 0], [1, -1]] would return a list containing both of the above
-    When multiple datasets are returned, they are placed on separate contour plots, but
-    the same line plot with different line styles.
+    Specify a linear combination of diagnostic data from different isweep signal sources (i.e. from different
+    probe faces), or multiple such linear combinations, from a diagnostic dataset.
+    The entries of `vectors` determine what linear combinations of data are plotted in `plots.py`.
 
     Parameters
     ----------
     ds : `xarray.Dataset`
         The Langmuir diagnostic dataset to select one or more probe-face linear combinations from.
     vectors : `list` of `list` of `list`
-        "3D" nested list of linear combination of isweep signals to compute (WIP)
+        3D nested list specifying one or more linear combinations of diagnostic data from different probes and faces.
+            - 2D entries in `vectors` each represent one linear combination.
+            - 1D sub-entries in an entry each correspond to one probe.
+            - 0D elements in these sub-entries give coefficients for diagnostic data from each face on that probe.
+              Diagnostic data from that probe face is multiplied by its coefficient and then summed.
+              Coefficients may be negative.
+        See `Examples` for examples.
 
     Returns
     -------
     `list` of `xarray.Dataset`
         List of datasets containing data from the selected isweep signal or combination of isweep signals (WIP)
+
+    Examples
+    --------
+    The below description may be helped by imagining a drawing of LAPD, similar to that in the comments of `main.py`,
+    overlaid above the 2D entry. Each element in an entry multiplies data from a specific probe face.
+    For a dataset with data from two Langmuir probes, each with two faces, in the parameter `vectors`,
+        - An entry of [[1, 0], [0, 0]] indicates *one* times the diagnostic data from the *first lexicographical* face
+          on the *lowest port number* probe
+        - An entry of [[0, 1], [0, 0]] indicates *one* times the diagnostic data from the *second lexicographical* face
+          on the *lowest port number* probe
+        - An entry of [[0, 0], [1, 0]] indicates *one* times the diagnostic data from the *first lexicographical* face
+          on the *second-lowest port number* probe
+        - An entry of [[0, 0], [-1, 0]] indicates the *negative* of the above data.
+        - An entry of [[1, 0], [-1, 0]] indicates the sum of the data from the first bullet point above and the fourth
+          bullet point above. It therefore indicates the parallel difference of data from equivalent faces
+          on the lower port number probe and on the higher port number probe (specifically, former minus latter).
+    Finally, if `vectors` as a whole takes the value [ [[1, 0], [0, 0]], [[1, 0], [-1, 0]] ], then the two linear
+    combinations of data described by the first and last bullet points above are returned.
     """
 
     manual_attrs = ds.attrs  # TODO raise xarray issue about losing attrs even with xr.set_options(keep_attrs=True):

--- a/lapd_plasma_analysis/langmuir/preview.py
+++ b/lapd_plasma_analysis/langmuir/preview.py
@@ -8,7 +8,8 @@ def preview_raw_sweep(bias, current, positions, langmuir_config, exp_params_dict
     Parameters
     ----------
     bias
-    currents
+    current : `astropy.units.Quantity`
+        2D array (dimensions: x-y position, shot at x-y position) of Langmuir sweep (collected) current
     positions
     langmuir_config
     exp_params_dict
@@ -23,46 +24,45 @@ def preview_raw_sweep(bias, current, positions, langmuir_config, exp_params_dict
 
     x = np.unique(positions[:, 0])
     y = np.unique(positions[:, 1])
-    print(f"\nDimensions of isweep array: "
-          f"{currents.shape[0]} isweep signals, "
+    print(f"Port {langmuir_config['port']}, face {langmuir_config['face']}")
+    print(f"\nDimensions of sweep bias and current array: "
           f"{len(x)} x-positions, "
           f"{len(y)} y-positions, and "
-          f"{currents.shape[2]} shots")
-    print(f"  * isweep port-face combinations are {ports_faces}",
-          f"  * x positions range from {min(x)} to {max(x)}",
+          f"{current.shape[1]} shots")
+    print(f"  * x positions range from {min(x)} to {max(x)}",
           f"  * y positions range from {min(y)} to {max(y)}",
-          f"  * shot indices range from 0 to {currents.shape[2]}.", sep="\n")
-    isweep_x_y_shot_to_plot = [0, 0, 0, 0]
-    variables_to_enter = ["isweep", "x position", "y position", "shot"]
+          f"  * shot indices range from 0 to {current.shape[1]}.", sep="\n")
+    x_y_shot_to_plot = [0, 0, 0]
+    variables_to_enter = ["x position", "y position", "shot"]
     print("\nNotes: \tIndices are zero-based; choose an integer between 0 and n - 1, inclusive."
           "\n \t \tEnter a non-integer below to quit raw sweep preview mode and continue to diagnostics.")
     sweep_view_mode = True
     while sweep_view_mode:
-        for i in range(len(isweep_x_y_shot_to_plot)):
+        for i in range(len(x_y_shot_to_plot)):
             try:
                 index_given = int(input(f"Enter a zero-based index for {variables_to_enter[i]}: "))
             except ValueError:
                 sweep_view_mode = False
                 break
-            isweep_x_y_shot_to_plot[i] = index_given
+            x_y_shot_to_plot[i] = index_given
         if not sweep_view_mode:
             break
         print()
 
         try:
-            loc_x, loc_y = x[isweep_x_y_shot_to_plot[1]], y[isweep_x_y_shot_to_plot[2]]
+            loc_x, loc_y = x[x_y_shot_to_plot[0]], y[x_y_shot_to_plot[1]]
             loc = (positions == [loc_x, loc_y]).all(axis=1).nonzero()[0][0]
 
             # Abbreviate "current" as "curr"
-            bias_to_plot = bias[(loc,                                    *isweep_x_y_shot_to_plot[3:])]
-            current_to_plot = currents[(isweep_x_y_shot_to_plot[0], loc, *isweep_x_y_shot_to_plot[3:])]
+            bias_to_plot = bias[(loc,       *x_y_shot_to_plot[2:])]
+            current_to_plot = current[(loc, *x_y_shot_to_plot[2:])]
 
             # String indicating port and face of sweep current source (e.g. "20L" or "27")
             port_face_string = f"{langmuir_config['port']}{langmuir_config['face'] if langmuir_config['face'] else ''}"
             plt.plot(np.arange(len(bias_to_plot)) * dt.to(u.ms).value, bias_to_plot)  # , label="Bias (V)")
             plt.title(f"Run: {exp_params_dict['Exp name']}, {exp_params_dict['Run name']}\n"
-                      f"Isweep: {isweep_x_y_shot_to_plot[0]} ({port_face_string}), "
-                      f"x: {loc_x}, y: {loc_y}, shot: {isweep_x_y_shot_to_plot[3]}\n\n"
+                      f"Probe port and face: {port_face_string}, "
+                      f"x: {loc_x}, y: {loc_y}, shot: {x_y_shot_to_plot[2]}\n\n"
                       f"Voltage [V]")
             plt.xlabel("Time [ms]")
             # plt.legend()

--- a/lapd_plasma_analysis/langmuir/preview.py
+++ b/lapd_plasma_analysis/langmuir/preview.py
@@ -10,7 +10,7 @@ def preview_raw_sweep(bias, current, positions, langmuir_config, exp_params_dict
     bias
     currents
     positions
-    ports_faces
+    langmuir_config
     exp_params_dict
     dt
     plot_save_directory
@@ -57,9 +57,8 @@ def preview_raw_sweep(bias, current, positions, langmuir_config, exp_params_dict
             bias_to_plot = bias[(loc,                                    *isweep_x_y_shot_to_plot[3:])]
             current_to_plot = currents[(isweep_x_y_shot_to_plot[0], loc, *isweep_x_y_shot_to_plot[3:])]
 
-            port_face = ports_faces[isweep_x_y_shot_to_plot[0]]
-            port_face_string = (str(port_face['port'])
-                                + (f" {port_face['face']}" if port_face['face'] else ""))
+            # String indicating port and face of sweep current source (e.g. "20L" or "27")
+            port_face_string = f"{langmuir_config['port']}{langmuir_config['face'] if langmuir_config['face'] else ''}"
             plt.plot(np.arange(len(bias_to_plot)) * dt.to(u.ms).value, bias_to_plot)  # , label="Bias (V)")
             plt.title(f"Run: {exp_params_dict['Exp name']}, {exp_params_dict['Run name']}\n"
                       f"Isweep: {isweep_x_y_shot_to_plot[0]} ({port_face_string}), "
@@ -74,8 +73,8 @@ def preview_raw_sweep(bias, current, positions, langmuir_config, exp_params_dict
 
             plt.plot(np.arange(len(bias_to_plot)) * dt.to(u.ms).value, current_to_plot)  # , label="Current (A)")
             plt.title(f"Run: {exp_params_dict['Exp name']}, {exp_params_dict['Run name']}\n"
-                      f"Isweep: {isweep_x_y_shot_to_plot[0]} ({port_face_string}), "
-                      f"x: {loc_x}, y: {loc_y}, shot: {isweep_x_y_shot_to_plot[3]}\n\n"
+                      f"Probe port and face: {port_face_string}, "
+                      f"x: {loc_x}, y: {loc_y}, shot: {x_y_shot_to_plot[2]}\n\n"
                       f"Current [A]")
             plt.xlabel("Time [ms]")
             # plt.legend()

--- a/lapd_plasma_analysis/langmuir/preview.py
+++ b/lapd_plasma_analysis/langmuir/preview.py
@@ -20,7 +20,7 @@ def preview_raw_sweep(bias, current, positions, langmuir_config, exp_params_dict
     -------
 
     """
-    plt.rcParams['figure.figsize'] = (8, 3)  # 40, 4 but decrease dpi!
+    plt.rcParams['figure.figsize'] = (8, 3)
 
     x = np.unique(positions[:, 0])
     y = np.unique(positions[:, 1])
@@ -35,7 +35,8 @@ def preview_raw_sweep(bias, current, positions, langmuir_config, exp_params_dict
     x_y_shot_to_plot = [0, 0, 0]
     variables_to_enter = ["x position", "y position", "shot"]
     print("\nNotes: \tIndices are zero-based; choose an integer between 0 and n - 1, inclusive."
-          "\n \t \tEnter a non-integer below to quit raw sweep preview mode and continue to diagnostics.")
+          "\n \t \tEnter a non-integer below to skip raw sweep preview mode for this isweep source "
+          "and continue to diagnostics.")
     sweep_view_mode = True
     while sweep_view_mode:
         for i in range(len(x_y_shot_to_plot)):

--- a/lapd_plasma_analysis/main.py
+++ b/lapd_plasma_analysis/main.py
@@ -16,8 +16,8 @@ from lapd_plasma_analysis.mach.analysis import get_mach_datasets, get_velocity_d
 
 # HDF5 file directory; end path with a slash                            # TODO user adjust
 # ----------------------------------------------------------------------------------------
-# hdf5_folder = "/Users/leomurphy/lapd-data/combined/"
-hdf5_folder = "/Users/leomurphy/lapd-data/November_2022/"
+hdf5_folder = "/Users/leomurphy/lapd-data/combined/"
+# hdf5_folder = "/Users/leomurphy/lapd-data/November_2022/"
 # hdf5_folder = "/Users/leomurphy/lapd-data/April_2018/"
 
 assert hdf5_folder.endswith("/")

--- a/lapd_plasma_analysis/main.py
+++ b/lapd_plasma_analysis/main.py
@@ -93,7 +93,7 @@ if __name__ == "__main__":
     print_user_file_choices(hdf5_folder, langmuir_nc_folder, interferometry_folder, interferometry_mode, isweep_choices)
     datasets, steady_state_times_runs, hdf5_paths = get_langmuir_datasets(
         langmuir_nc_folder, hdf5_folder, interferometry_folder, interferometry_mode,
-        isweep_choices, core_radius, bimaxwellian, plot_save_folder)
+        core_radius, bimaxwellian, plot_save_folder)
 
     print("\n===== Mach probe analysis =====")
     mach_datasets = get_mach_datasets(mach_nc_folder, hdf5_folder, datasets, hdf5_paths, mach_velocity_mode)


### PR DESCRIPTION
Old: load sweep (Langmuir probe) bias and all sweep current signals first, then split into ramps and create all Characteristic objects next. New: load sweep bias, then one sweep current signal (i.e. signal from one Langmuir probe face). Create characteristics for this signal, then delete unnecessary sweep current signal. Proceed for the next sweep current signals. Reduce RAM usage by 60% (10 GB -> 4 GB) or more, especially in Jan 2024 experiments with many probes and faces.