### PR TITLE
Save metadata, mark up plots

### DIFF
--- a/lapd_plasma_analysis/langmuir/analysis.py
+++ b/lapd_plasma_analysis/langmuir/analysis.py
@@ -271,6 +271,13 @@ def load_datasets(hdf5_folder, lang_nc_folder, bimaxwellian, plot_save_directory
                 characteristic_array = make_characteristic_array(bias, current, ramp_bounds)
                 characteristic_arrays += [characteristic_array]
 
+                if chara_view_mode:
+                    preview_characteristics(characteristic_array, position_array, ramp_times,
+                                            langmuir_configs[i], exp_params_dict,
+                                            diagnostics=True, ion=ion_type,
+                                            bimaxwellian=bimaxwellian,
+                                            plot_save_directory=plot_save_directory)
+
                 # cleanup 1
                 del current
 
@@ -286,14 +293,7 @@ def load_datasets(hdf5_folder, lang_nc_folder, bimaxwellian, plot_save_directory
             #  to represent characteristics (sweep curves) from different probes or probe faces.
             #  Probe/face combinations are ordered by the order of elements in langmuir_configs, from configurations.py.
 
-            if chara_view_mode:
-                preview_characteristics(characteristics, positions, ramp_times,
-                                        langmuir_configs, exp_params_dict,
-                                        diagnostics=True, ion=ion_type,
-                                        bimaxwellian=bimaxwellian,
-                                        plot_save_directory=plot_save_directory)
-
-            # perform langmuir diagnostics on each dataset
+            # Perform langmuir diagnostics on each dataset
             diagnostics_dataset = langmuir_diagnostics(characteristics, positions, ramp_times,
                                                        langmuir_configs, ion_type, bimaxwellian=bimaxwellian)
 

--- a/lapd_plasma_analysis/langmuir/plots.py
+++ b/lapd_plasma_analysis/langmuir/plots.py
@@ -248,7 +248,7 @@ def plot_linear_diagnostic(diagnostics_dataset: xr.Dataset, probe_face_coefficie
                         probe_eq_string = probe_face_choice_to_eq_string(probe_face_coefficients[d],
                                                                          diagnostics_dataset.coords['port'].data,
                                                                          diagnostics_dataset.coords['face'].data)
-                        plot_title += f", {probe_eq_string}"
+                        plot_title += f", port/face {probe_eq_string}"
                     except (ValueError, TypeError, AttributeError, KeyError, IndexError) as e:
                         print(e)
                         pass

--- a/lapd_plasma_analysis/langmuir/preview.py
+++ b/lapd_plasma_analysis/langmuir/preview.py
@@ -31,12 +31,12 @@ def preview_raw_sweep(bias, current, positions, langmuir_config, exp_params_dict
           f"{current.shape[1]} shots")
     print(f"  * x positions range from {min(x)} to {max(x)}",
           f"  * y positions range from {min(y)} to {max(y)}",
-          f"  * shot indices range from 0 to {current.shape[1]}.", sep="\n")
+          f"  * shot indices range from 0 to {current.shape[1] - 1}.", sep="\n")
     x_y_shot_to_plot = [0, 0, 0]
     variables_to_enter = ["x position", "y position", "shot"]
     print("\nNotes: \tIndices are zero-based; choose an integer between 0 and n - 1, inclusive."
-          "\n \t \tEnter a non-integer below to skip raw sweep preview mode for this isweep source "
-          "and continue to diagnostics.")
+          "\n \t \tEnter a non-integer below (such as the empty string) to skip raw sweep preview mode "
+          "for this isweep source and continue to diagnostics.")
     sweep_view_mode = True
     while sweep_view_mode:
         for i in range(len(x_y_shot_to_plot)):
@@ -88,7 +88,7 @@ def preview_raw_sweep(bias, current, positions, langmuir_config, exp_params_dict
             continue
 
 
-def preview_characteristics(characteristics_array, positions, ramp_times, langmuir_configs, exp_params_dict,
+def preview_characteristics(characteristics_array, positions, ramp_times, langmuir_config, exp_params_dict,
                             diagnostics=False, ion=None, bimaxwellian=False, plot_save_directory=""):
     """
     WIP
@@ -98,7 +98,7 @@ def preview_characteristics(characteristics_array, positions, ramp_times, langmu
     characteristics_array
     positions
     ramp_times
-    langmuir_configs
+    langmuir_config
     exp_params_dict
     diagnostics
     ion
@@ -109,61 +109,57 @@ def preview_characteristics(characteristics_array, positions, ramp_times, langmu
     -------
 
     """
-    ports_faces = langmuir_configs[['port', 'face']]
-    areas = langmuir_configs['area']
+
+    area = langmuir_config['area']
     plt.rcParams['figure.figsize'] = (6, 4)
 
     x = np.unique(positions[:, 0])
     y = np.unique(positions[:, 1])
-    print(f"\nDimensions of plateaus array: "
-          f"{characteristics_array.shape[0]} isweep signals, "
+    print(f"\nPort {langmuir_config['port']}, face {langmuir_config['face']}")
+    print(f"Dimensions of plateaus array: "
           f"{len(x)} x-positions, "
           f"{len(y)} y-positions, "
           f"{characteristics_array.shape[2]} shots, and "
           f"{characteristics_array.shape[-1]} ramps.")
-    print(f"  * isweep port-face combinations are {ports_faces}",
-          f"  * x positions range from {min(x)} to {max(x)}",
+    print(f"  * x positions range from {min(x)} to {max(x)}",
           f"  * y positions range from {min(y)} to {max(y)}",
           f"  * shot indices range from 0 to {characteristics_array.shape[2]}",
           f"  * ramp times range from {min(ramp_times):.2f} to {max(ramp_times):.2f}.", sep="\n")
-    isweep_x_y_shot_ramp_to_plot = [0, 0, 0, 0, 0]
-    variables_to_enter = ["isweep", "x position", "y position", "shot", "ramp"]
+    x_y_shot_ramp_to_plot = [0, 0, 0, 0]
+    variables_to_enter = ["x position", "y position", "shot", "ramp"]
     print("\nNotes: \tIndices are zero-based; choose an integer between 0 and n - 1, inclusive."
-          "\n \t \tEnter a non-integer below to quit characteristic preview mode and continue to diagnostics.")
+          "\n \t \tEnter a non-integer below (such as the empty string) to quit characteristic preview mode "
+          "and continue to diagnostics.")
     chara_view_mode = True
     while chara_view_mode:
-        for i in range(len(isweep_x_y_shot_ramp_to_plot)):
+        for i in range(len(x_y_shot_ramp_to_plot)):
             try:
                 index_given = int(input(f"Enter a zero-based index for {variables_to_enter[i]}: "))
             except ValueError:
                 chara_view_mode = False
                 break
-            isweep_x_y_shot_ramp_to_plot[i] = index_given
+            x_y_shot_ramp_to_plot[i] = index_given
         if not chara_view_mode:
             break
         print()
 
         try:
-            loc_x, loc_y = x[isweep_x_y_shot_ramp_to_plot[1]], y[isweep_x_y_shot_ramp_to_plot[2]]
+            loc_x, loc_y = x[x_y_shot_ramp_to_plot[0]], y[x_y_shot_ramp_to_plot[1]]
             loc = (positions == [loc_x, loc_y]).all(axis=1).nonzero()[0][0]
-            chara_to_plot = characteristics_array[(isweep_x_y_shot_ramp_to_plot[0], loc,
-                                                   *isweep_x_y_shot_ramp_to_plot[3:])]
+            chara_to_plot = characteristics_array[(loc, *x_y_shot_ramp_to_plot[2:])]
             """ while chara_view_mode not in ["s", "a"]:
                 chara_view_mode = input("(S)how current plot or (a)dd another Characteristic?").lower()
             if chara_view_mode == "s": """
-            port_face = ports_faces[isweep_x_y_shot_ramp_to_plot[0]]
-            port_face_string = (str(port_face['port'])
-                                + (f" {port_face['face']}" if port_face['face'] else ""))
+            port_face_string = (str(langmuir_config['port'])
+                                + (f" {langmuir_config['face']}" if langmuir_config['face'] else ""))
             plot_title = (f"Run: {exp_params_dict['Exp name']}, {exp_params_dict['Run name']}\n"
-                          f"Isweep: {isweep_x_y_shot_ramp_to_plot[0]} ({port_face_string}), "
-                          f"x: {loc_x}, y: {loc_y}, shot: {isweep_x_y_shot_ramp_to_plot[3]}, "
-                          f"time: {ramp_times[isweep_x_y_shot_ramp_to_plot[4]]:.2f}")
+                          f"x: {loc_x}, y: {loc_y}, shot: {x_y_shot_ramp_to_plot[2]}, "
+                          f"time: {ramp_times[x_y_shot_ramp_to_plot[3]]:.2f}")
             if diagnostics:
-                if areas is None or ion is None:
+                if area is None or ion is None:
                     raise ValueError("Area or ion not specified in characteristic preview mode, but 'diagnostics' is True.")
                 try:
-                    diagnostics = swept_probe_analysis(chara_to_plot, areas[isweep_x_y_shot_ramp_to_plot[0]], ion,
-                                                       bimaxwellian)
+                    diagnostics = swept_probe_analysis(chara_to_plot, area, ion, bimaxwellian)
                     electron_temperature = diagnostics['T_e'] if not bimaxwellian \
                         else unpack_bimaxwellian(diagnostics)['T_e_avg']
                     ion_density = diagnostics['n_i_OML']


### PR DESCRIPTION
* Save contents, structure, use, and source metadata with every Langmuir diagnostic NetCDF dataset
* Print steady-state periods to console
* Show core region and steady-state period on contour plots
* Preview sweep curves from only one isweep signal at a time