### PR TITLE
Save descriptive metadata with mach NetCDF dataset files

### DIFF
--- a/lapd_plasma_analysis/mach/analysis.py
+++ b/lapd_plasma_analysis/mach/analysis.py
@@ -9,6 +9,7 @@ from lapd_plasma_analysis.langmuir.analysis import save_datasets_nc
 from lapd_plasma_analysis.langmuir.configurations import get_ion
 
 from lapd_plasma_analysis.mach.getMachIsat import get_mach_isat
+from lapd_plasma_analysis.mach.metadata_for_dataset import get_supplemental_metadata
 from lapd_plasma_analysis.mach.velocity import get_mach_numbers, get_velocity
 from lapd_plasma_analysis.mach.configurations import get_mach_config
 
@@ -72,6 +73,9 @@ def get_mach_datasets(mach_nc_folder, hdf5_folder, lang_datasets, hdf5_selected_
             mach_isat = get_mach_isat(hdf5_path, mach_configs)
 
             mach_datasets += [get_mach_numbers(mach_isat).assign_attrs(exp_params_dict)]
+
+        for i in range(len(mach_datasets)):
+            mach_datasets[i] = mach_datasets[i].assign_attrs(get_supplemental_metadata(mach_datasets[i]))
 
         # Save Mach datasets as separate NetCDF files
         save_datasets_nc(mach_datasets, mach_nc_folder, "mach_")

--- a/lapd_plasma_analysis/mach/metadata_for_dataset.py
+++ b/lapd_plasma_analysis/mach/metadata_for_dataset.py
@@ -4,14 +4,13 @@ Provide messages to add to each saved dataset (WIP) # todo
 
 from lapd_plasma_analysis.langmuir.plots import get_title
 
-
 # General metadata
 
 general = """
 General information
 
 This object is a dataset containing data from one experiment at the Large Plasma Device (LAPD) at UCLA.
-This dataset is in the NetCDF format and contains Langmuir (and maybe Mach) probe diagnostic data.
+This dataset is in the NetCDF format and contains Mach probe data.
 This data can be accessed through Python, for example, by using the xarray library's open_dataset function.
 Diagnostic data was calculated from experiments using the online lapd-plasma-analysis library.
 For more information, see the 'contents', 'structure', 'use', and 'source' elements 
@@ -32,7 +31,7 @@ def get_supplemental_metadata(dataset):
 contents = """
 Contents information
 
-This dataset is an instance of `xarray.Dataset`. It contains the following variables, referred to by
+This dataset is an instance of `xarray.Dataset`. It contains the following variable(s), referred to by
 their Dataset variable (short) name followed by their descriptive (long) name:
     {variables_list_string} 
 Visit https://docs.xarray.dev/en/stable/index.html for documentation and information on xarray Datasets and DataArrays.
@@ -154,15 +153,10 @@ def get_use_metadata(dataset):
 source = """
 Source information
 
-Langmuir diagnostic values were calculated using lapd-plasma-analysis 
-with the help of the diagnostics toolkit of the PlasmaPy library.
+Mach number values were calculated using lapd-plasma-analysis.
 Documentation for the lapd-plasma-analysis library is available online at this link: 
     https://lapd-plasma-analysis.readthedocs.io/en/index.html
-Documentation for the PlasmaPy library is available online at these links: 
-    https://docs.plasmapy.org/en/stable/
-    https://docs.plasmapy.org/en/stable/ad/diagnostics/langmuir.html
-
-Further information on lapd-plasma-analysis is not yet complete. (WIP)
+Further information on Mach number calculations is not yet complete. (WIP)
 """
 
 # TODO most important part - how was this data calculated?

--- a/lapd_plasma_analysis/main.py
+++ b/lapd_plasma_analysis/main.py
@@ -41,7 +41,7 @@ interferometry_folder = ("/Users/leomurphy/lapd-data/November_2022/uwave_288_GHz
 
 # Interferometry & Mach access modes. Options are "skip", "append", "overwrite"; recommended is "append".
 interferometry_mode = "skip"                                            # TODO user adjust
-mach_velocity_mode = "skip"                                           # not fully implemented
+mach_velocity_mode = "append"                                           # not fully implemented
 
 # ----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
* Create mach/metadata_for_dataset.py like langmuir/metadata_for_dataset.py to auto-generate information on content, structure, and use of Mach number data
* Simplify sample code in both metadata_for_dataset.py files